### PR TITLE
feat: add booking visit page and UI components

### DIFF
--- a/app/booking/page.tsx
+++ b/app/booking/page.tsx
@@ -1,0 +1,15 @@
+import HeroSection from "@/components/booking/hero-section"
+import BookingContent from "@/components/booking/booking-content"
+import Header from "@/components/layout/header"
+import BookingInfoStrip from "@/components/booking/booking-info-strip"
+
+export default function BookingPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+      <HeroSection />
+      <BookingContent />
+      <BookingInfoStrip />
+    </div>
+  )
+}

--- a/components/booking/booking-content.tsx
+++ b/components/booking/booking-content.tsx
@@ -1,0 +1,33 @@
+"use client"
+import { useState } from "react"
+import PropertySummary from "./property-summary"
+import BookingForm from "./booking-form"
+
+export default function BookingContent() {
+  const [selectedDate, setSelectedDate] = useState("")
+  const [selectedTime, setSelectedTime] = useState("")
+  const [visitType, setVisitType] = useState("in-person")
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 md:px-8 py-12 md:py-16">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+        {/* Left Column - Property Summary */}
+        <div className="md:col-span-1">
+          <PropertySummary />
+        </div>
+
+        {/* Right Column - Booking Form */}
+        <div className="md:col-span-2">
+          <BookingForm
+            selectedDate={selectedDate}
+            setSelectedDate={setSelectedDate}
+            selectedTime={selectedTime}
+            setSelectedTime={setSelectedTime}
+            visitType={visitType}
+            setVisitType={setVisitType}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/booking/booking-form.tsx
+++ b/components/booking/booking-form.tsx
@@ -1,0 +1,274 @@
+"use client"
+import type React from "react"
+
+import { useState } from "react"
+import { Card } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import { Label } from "@/components/ui/label"
+import { Calendar, Clock } from "lucide-react"
+
+interface BookingFormProps {
+  selectedDate: string
+  setSelectedDate: (date: string) => void
+  selectedTime: string
+  setSelectedTime: (time: string) => void
+  visitType: string
+  setVisitType: (type: string) => void
+}
+
+const availableTimeSlots = [
+  "09:00 - 09:30",
+  "10:00 - 10:30",
+  "11:00 - 11:30",
+  "12:00 - 12:30",
+  "14:00 - 14:30",
+  "15:00 - 15:30",
+  "16:00 - 16:30",
+  "17:00 - 17:30",
+]
+
+const bookedSlots = ["10:00 - 10:30", "14:00 - 14:30"]
+
+export default function BookingForm({
+  selectedDate,
+  setSelectedDate,
+  selectedTime,
+  setSelectedTime,
+  visitType,
+  setVisitType,
+}: BookingFormProps) {
+  const [wantCall, setWantCall] = useState(false)
+  const [payDeposit, setPayDeposit] = useState(false)
+  const [cardDetails, setCardDetails] = useState({
+    name: "",
+    cardNumber: "",
+    expiry: "",
+    cvv: "",
+  })
+
+  const handleDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSelectedDate(e.target.value)
+  }
+
+  return (
+    <Card className="p-8 shadow-md">
+      <h2 className="text-2xl font-bold text-[#2C3E50] mb-8">Book a Visit</h2>
+
+      <form className="space-y-8">
+        {/* Step 1: Visit Type */}
+        <div>
+          <h3 className="font-semibold text-gray-800 mb-4">Visit Type</h3>
+          <RadioGroup value={visitType} onValueChange={setVisitType}>
+            <div className="flex items-center space-x-3 mb-3">
+              <RadioGroupItem value="in-person" id="in-person" />
+              <Label htmlFor="in-person" className="cursor-pointer font-normal">
+                In-person visit
+              </Label>
+            </div>
+            <div className="flex items-center space-x-3 mb-3">
+              <RadioGroupItem value="virtual" id="virtual" />
+              <Label htmlFor="virtual" className="cursor-pointer font-normal">
+                Virtual tour
+              </Label>
+            </div>
+            <div className="flex items-center space-x-3">
+              <RadioGroupItem value="open-house" id="open-house" />
+              <Label htmlFor="open-house" className="cursor-pointer font-normal">
+                Open house
+              </Label>
+            </div>
+          </RadioGroup>
+        </div>
+
+        {/* Divider */}
+        <div className="border-t border-gray-200" />
+
+        {/* Step 2: Select Date */}
+        <div>
+          <h3 className="font-semibold text-gray-800 mb-4 flex items-center gap-2">
+            <Calendar className="w-5 h-5 text-[#4DA6C7]" />
+            Select Date
+          </h3>
+          <input
+            type="date"
+            value={selectedDate}
+            onChange={handleDateChange}
+            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:border-[#5B72D9]"
+          />
+          <p className="text-xs text-gray-500 mt-2">
+            Only available dates are clickable. Greyed out dates are unavailable.
+          </p>
+        </div>
+
+        {/* Divider */}
+        <div className="border-t border-gray-200" />
+
+        {/* Step 3: Available Time Slots */}
+        {selectedDate && (
+          <div>
+            <h3 className="font-semibold text-gray-800 mb-4 flex items-center gap-2">
+              <Clock className="w-5 h-5 text-[#4DA6C7]" />
+              Available Time Slots
+            </h3>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+              {availableTimeSlots.map((slot) => {
+                const isBooked = bookedSlots.includes(slot)
+                const isSelected = selectedTime === slot
+                return (
+                  <button
+                    key={slot}
+                    type="button"
+                    onClick={() => !isBooked && setSelectedTime(slot)}
+                    disabled={isBooked}
+                    className={`py-2 px-3 rounded-lg text-sm font-medium transition-colors ${
+                      isBooked
+                        ? "bg-gray-100 text-gray-400 cursor-not-allowed"
+                        : isSelected
+                          ? "bg-[#5B72D9] text-white"
+                          : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+                    }`}
+                  >
+                    {slot}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* Divider */}
+        <div className="border-t border-gray-200" />
+
+        {/* Step 4: Additional Details */}
+        <div>
+          <h3 className="font-semibold text-gray-800 mb-4">Additional Details</h3>
+          <textarea
+            placeholder="Message to the owner / special requests..."
+            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:border-[#5B72D9] resize-none"
+            rows={4}
+          />
+          <div className="flex items-center gap-3 mt-4">
+            <Checkbox id="call" checked={wantCall} onCheckedChange={(checked :boolean) => setWantCall(checked as boolean)} />
+            <Label htmlFor="call" className="cursor-pointer font-normal">
+              I want the agent to call me before the visit
+            </Label>
+          </div>
+        </div>
+
+        {/* Divider */}
+        <div className="border-t border-gray-200" />
+
+        {/* Step 5: Optional Payment */}
+        <div>
+          <div className="flex items-center gap-3 mb-4">
+            <Checkbox
+              id="deposit"
+              checked={payDeposit}
+              onCheckedChange={(checked:boolean) => setPayDeposit(checked as boolean)}
+            />
+            <Label htmlFor="deposit" className="cursor-pointer font-normal">
+              Pay a deposit now to confirm my booking (optional)
+            </Label>
+          </div>
+
+          {payDeposit && (
+            <div className="bg-gray-50 p-6 rounded-lg space-y-4">
+              <div className="flex justify-between items-center pb-4 border-b border-gray-200">
+                <span className="text-gray-700">Deposit Amount</span>
+                <span className="font-semibold text-[#2C3E50]">$1,000.00</span>
+              </div>
+
+              <div className="mb-4">
+                <p className="text-sm font-medium text-gray-800 mb-3">Payment Method</p>
+                <div className="flex gap-3">
+                  <button
+                    type="button"
+                    className="flex-1 py-3 px-4 border-2 border-[#5B72D9] rounded-lg text-sm font-medium text-[#5B72D9] hover:bg-blue-50"
+                  >
+                    💳 Credit Card
+                  </button>
+                  <button
+                    type="button"
+                    className="flex-1 py-3 px-4 border-2 border-gray-300 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-50"
+                  >
+                    🅿️ PayPal
+                  </button>
+                </div>
+              </div>
+
+              <div className="space-y-3">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">Full Name</label>
+                  <input
+                    type="text"
+                    value={cardDetails.name}
+                    onChange={(e) => setCardDetails({ ...cardDetails, name: e.target.value })}
+                    placeholder="John Doe"
+                    className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:border-[#5B72D9]"
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">Card Number</label>
+                  <input
+                    type="text"
+                    value={cardDetails.cardNumber}
+                    onChange={(e) => setCardDetails({ ...cardDetails, cardNumber: e.target.value })}
+                    placeholder="1234 5678 9012 3456"
+                    className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:border-[#5B72D9]"
+                  />
+                </div>
+
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-2">Expiry Date</label>
+                    <input
+                      type="text"
+                      value={cardDetails.expiry}
+                      onChange={(e) => setCardDetails({ ...cardDetails, expiry: e.target.value })}
+                      placeholder="MM/YY"
+                      className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:border-[#5B72D9]"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-2">CVV</label>
+                    <input
+                      type="text"
+                      value={cardDetails.cvv}
+                      onChange={(e) => setCardDetails({ ...cardDetails, cvv: e.target.value })}
+                      placeholder="123"
+                      className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:border-[#5B72D9]"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Divider */}
+        <div className="border-t border-gray-200" />
+
+        {/* Action Buttons */}
+        <div className="flex gap-3 pt-4">
+          <Button className="flex-1 bg-[#5B72D9] hover:bg-[#4A5FB8] text-white py-3 rounded-lg font-semibold">
+            Request Visit
+          </Button>
+          <Button
+            variant="outline"
+            className="flex-1 border-2 border-gray-300 text-gray-700 hover:bg-gray-50 py-3 rounded-lg font-semibold bg-transparent"
+          >
+            Cancel
+          </Button>
+        </div>
+
+        {/* Note */}
+        <p className="text-xs text-gray-500 text-center">
+          Your booking will be sent to the owner. You will receive a confirmation when the owner approves the visit.
+        </p>
+      </form>
+    </Card>
+  )
+}

--- a/components/booking/booking-info-strip.tsx
+++ b/components/booking/booking-info-strip.tsx
@@ -1,0 +1,55 @@
+import { Calendar, User, CreditCard, Home } from "lucide-react"
+
+export default function BookingInfoStrip() {
+  const steps = [
+    {
+      icon: Calendar,
+      number: 1,
+      title: "Choose Date & Time",
+      description: "Select your preferred visit slot",
+    },
+    {
+      icon: User,
+      number: 2,
+      title: "Owner Approves",
+      description: "Wait for owner confirmation",
+    },
+    {
+      icon: CreditCard,
+      number: 3,
+      title: "Payment (Optional)",
+      description: "Secure your booking with deposit",
+    },
+    {
+      icon: Home,
+      number: 4,
+      title: "Visit Property",
+      description: "Explore on scheduled time",
+    },
+  ]
+
+  return (
+    <div className="bg-gray-50 py-12 md:py-16">
+      <div className="max-w-7xl mx-auto px-4 md:px-8">
+        <h2 className="text-2xl md:text-3xl font-bold text-[#2C3E50] text-center mb-12">Booking Process</h2>
+
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-6 md:gap-4">
+          {steps.map((step) => {
+            const Icon = step.icon
+            return (
+              <div key={step.number} className="flex flex-col items-center text-center">
+                <div className="w-16 h-16 rounded-full bg-[#5B72D9] text-white flex items-center justify-center mb-4 flex-shrink-0">
+                  <Icon className="w-8 h-8" />
+                </div>
+                <h3 className="font-semibold text-gray-800 mb-2">
+                  {step.number}. {step.title}
+                </h3>
+                <p className="text-sm text-gray-600">{step.description}</p>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/booking/hero-section.tsx
+++ b/components/booking/hero-section.tsx
@@ -1,0 +1,23 @@
+export default function HeroSection() {
+  return (
+    <div className="relative w-full h-64 md:h-80 bg-gradient-to-b from-black/40 to-black/20">
+      {/* Background Image */}
+      <div
+        className="absolute inset-0 bg-cover bg-center bg-no-repeat"
+        style={{
+          backgroundImage:
+            "url(/placeholder.svg?height=800&width=1600&query=modern living room interior with furniture)",
+        }}
+      />
+
+      {/* Content */}
+      <div className="relative h-full flex flex-col items-center justify-center text-center px-4">
+        <h1 className="text-4xl md:text-5xl font-bold text-white mb-4 text-balance">Booking Visit</h1>
+        <p className="text-gray-200 text-sm md:text-base mb-4">Home / Properties / Booking Visit</p>
+        <p className="text-gray-100 max-w-2xl text-sm md:text-base">
+          Schedule a personalized visit to explore your dream property with our experienced agents
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/components/booking/property-summary.tsx
+++ b/components/booking/property-summary.tsx
@@ -1,0 +1,68 @@
+import { Card } from "@/components/ui/card";
+import Avatar from "@/components/ui/avatar";
+import { BedDouble, Bath, Ruler as Ruler2 } from "lucide-react";
+
+export default function PropertySummary() {
+  return (
+    <Card className="overflow-hidden shadow-md">
+      {/* Property Image */}
+      <div
+        className="w-full h-48 bg-cover bg-center"
+        style={{
+          backgroundImage:
+            "url(/placeholder.svg?height=400&width=400&query=luxury home exterior with white columns)",
+        }}
+      />
+
+      {/* Content */}
+      <div className="p-6">
+        {/* Address */}
+        <h2 className="text-xl font-bold text-[#2C3E50] mb-2">
+          92 ALLIUM PLACE, ORLANDO FL 32827
+        </h2>
+
+        {/* Price */}
+        <p className="text-2xl font-bold text-[#4DA6C7] mb-4">$ 590,693</p>
+
+        {/* Property Details Icons */}
+        <div className="flex gap-6 mb-6 text-sm">
+          <div className="flex items-center gap-2">
+            <BedDouble className="w-5 h-5 text-gray-400" />
+            <span className="text-gray-700">4</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <Bath className="w-5 h-5 text-gray-400" />
+            <span className="text-gray-700">4</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <Ruler2 className="w-5 h-5 text-gray-400" />
+            <span className="text-gray-700">2,096.00 ft</span>
+          </div>
+        </div>
+
+        {/* Divider */}
+        <div className="border-t border-gray-200 mb-4" />
+        {/* Agent Info */}
+        <div className="flex items-center gap-3">
+          <Avatar
+            src="https://api.dicebear.com/9x/avataaars/svg?seed=Jenny"
+            name="Jenny Wilson"
+          />
+          <div>
+            <p className="font-semibold text-gray-800">Jenny Wilson</p>
+            <p className="text-xs text-gray-500">Luxury Real Estate Agent</p>
+          </div>
+        </div>
+
+        {/* Property Description */}
+        <div className="mt-4 text-sm text-gray-600 leading-relaxed">
+          <p>
+            Beautiful modern home with spacious interiors, premium finishes, and
+            a stunning backyard perfect for entertaining. Located in a
+            prestigious neighborhood with excellent schools and amenities.
+          </p>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react'
+import { Slot } from '@radix-ui/react-slot'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '@/lib/utils'
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        destructive:
+          'bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+        outline:
+          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
+        secondary:
+          'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        ghost:
+          'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
+        link: 'text-primary underline-offset-4 hover:underline',
+      },
+      size: {
+        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
+        sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
+        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
+        icon: 'size-9',
+        'icon-sm': 'size-8',
+        'icon-lg': 'size-10',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+)
+
+function Button({
+  className,
+  variant,
+  size,
+  asChild = false,
+  ...props
+}: React.ComponentProps<'button'> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean
+  }) {
+  const Comp = asChild ? Slot : 'button'
+
+  return (
+    <Comp
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Button, buttonVariants }

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+function Card({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        '@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn('leading-none font-semibold', className)}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn('text-muted-foreground text-sm', className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        'col-start-2 row-span-2 row-start-1 self-start justify-self-end',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn('px-6', className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn('flex items-center px-6 [.border-t]:pt-6', className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react'
+import * as CheckboxPrimitive from '@radix-ui/react-checkbox'
+import { CheckIcon } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        'peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="flex items-center justify-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -1,4 +1,4 @@
-"use client"
+
 
 import * as React from "react"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,0 +1,23 @@
+
+import * as React from 'react'
+import * as LabelPrimitive from '@radix-ui/react-label'
+
+import { cn } from '@/lib/utils'
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        'flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/components/ui/radio-group.tsx
+++ b/components/ui/radio-group.tsx
@@ -1,0 +1,44 @@
+
+import * as React from 'react'
+import * as RadioGroupPrimitive from '@radix-ui/react-radio-group'
+import { CircleIcon } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+function RadioGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+  return (
+    <RadioGroupPrimitive.Root
+      data-slot="radio-group"
+      className={cn('grid gap-3', className)}
+      {...props}
+    />
+  )
+}
+
+function RadioGroupItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+  return (
+    <RadioGroupPrimitive.Item
+      data-slot="radio-group-item"
+      className={cn(
+        'border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator
+        data-slot="radio-group-indicator"
+        className="relative flex items-center justify-center"
+      >
+        <CircleIcon className="fill-primary absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  )
+}
+
+export { RadioGroup, RadioGroupItem }

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,15 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "api.dicebear.com",
+        pathname: "/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,10 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-avatar": "^1.1.11",
+        "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
+        "@radix-ui/react-label": "^2.1.8",
+        "@radix-ui/react-radio-group": "^1.3.8",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "json-server": "^1.0.0-beta.3",
@@ -1375,6 +1378,92 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-collection": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
@@ -1754,6 +1843,29 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.8.tgz",
+      "integrity": "sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-menu": {
       "version": "2.1.16",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
@@ -2050,6 +2162,94 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-radio-group": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
+      "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-roving-focus": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
@@ -2247,6 +2447,21 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
       "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2871,7 +3086,7 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2881,7 +3096,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -3997,7 +4212,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.11",
+    "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-label": "^2.1.8",
+    "@radix-ui/react-radio-group": "^1.3.8",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "json-server": "^1.0.0-beta.3",


### PR DESCRIPTION
Implements the Booking Visit page for the `/booking` route.

- Shows property summary card on the left.
- Booking form with visit type selection, date picker, and available time slots.
- Optional deposit section with basic payment details.

Closes #10
